### PR TITLE
Add card sales cache and HTML report

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,4 +5,6 @@ SEARCH_PHRASE=twój przedmiot został sprzedany
 FOLDER=Vinted/Sprzedane
 OUTPUT_PATH=/path/to/orders.json
 CARDS_OUTPUT_PATH=/path/to/latest_order_cards.json
+CARDS_CACHE_PATH=/path/to/cards_cache.json
+CARDS_HTML_PATH=/path/to/cards_count.html
 API_KEY=your-api-key

--- a/cards_count.html
+++ b/cards_count.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="pl">
+<head>
+<meta charset="UTF-8">
+<title>Sprzedane karty</title>
+<style>
+  body { font-family: Arial, sans-serif; color: white; background: transparent; }
+  table { border-collapse: collapse; }
+  td, th { border: 1px solid white; padding: 4px 8px; }
+</style>
+</head>
+<body>
+<table>
+<tr><th>Karta</th><th>Ilość</th></tr>
+</table>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- track processed emails and card counts in a cache file
- generate `cards_count.html` summary of all sold cards
- update environment example with new variables

## Testing
- `python -m py_compile vinted_orders.py`


------
https://chatgpt.com/codex/tasks/task_e_684fc99167a4832f91cb9cce09b05c3e