### PR TITLE
Add all cards storage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,4 +7,5 @@ OUTPUT_PATH=/path/to/orders.json
 CARDS_OUTPUT_PATH=/path/to/latest_order_cards.json
 CARDS_CACHE_PATH=/path/to/cards_cache.json
 CARDS_HTML_PATH=/path/to/cards_count.html
+ALL_CARDS_PATH=/path/to/all_order_cards.json
 API_KEY=your-api-key


### PR DESCRIPTION
## Summary
- support ALL_CARDS_PATH env var for location of file with all cards
- keep cache of all cards and update it on new orders
- update .env example

## Testing
- `python -m py_compile vinted_orders.py`

------
https://chatgpt.com/codex/tasks/task_e_684ff987c348832f86e220728fb32aef