### PR TITLE
Fix card display timing

### DIFF
--- a/karty.html
+++ b/karty.html
@@ -130,11 +130,14 @@
     const video = document.getElementById("transition");
     video.style.opacity = 1;
     video.currentTime = 0;
-    video.play();
+    await video.play();
 
-    setTimeout(() => {
-      video.style.opacity = 0;
-    }, 4000);
+    await new Promise(resolve => {
+      video.onended = () => {
+        video.style.opacity = 0;
+        resolve();
+      };
+    });
 
     for (const card of cards) {
       await showCard(card);


### PR DESCRIPTION
## Summary
- ensure the card display waits for the transition video to finish

## Testing
- `python -m http.server 8000 >/tmp/http.log 2>&1 &` *(fails: missing output due to environment)*

------
https://chatgpt.com/codex/tasks/task_e_685018923c04832f86c50ff825ecfcbd