### PR TITLE
Fix card number normalization for API queries

### DIFF
--- a/vinted_orders.py
+++ b/vinted_orders.py
@@ -54,7 +54,12 @@ def decode_mime_words(s):
 
 def search_card_in_api(name, number):
     """Search for a card in the API using a normalized name and number."""
-    number = re.sub(r"^\D+", "", number).lstrip("0")
+    # Preserve possible set prefixes in the card number (e.g. "SV21", "SWSH105")
+    # while removing spaces and any trailing set size like "119/198".
+    number = number.strip().lstrip("#")
+    number = number.replace(" ", "")
+    if "/" in number:
+        number = number.split("/")[0]
     name = name.strip()
 
     query = f'name:"{name}" number:{number}'


### PR DESCRIPTION
## Summary
- preserve letter prefixes in card numbers when querying Pokemon TCG API

## Testing
- `python -m py_compile vinted_orders.py`


------
https://chatgpt.com/codex/tasks/task_e_68501d3f0b4c832f847b4e3d1aecc81a