### PR TITLE
Fix search all emails

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,3 +10,4 @@ CARDS_HTML_PATH=/path/to/cards_count.html
 ALL_CARDS_PATH=/path/to/all_order_cards.json
 API_KEY=your-api-key
 SEARCH_DAYS=10
+# Set to 0 to search the entire mailbox

--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ API_KEY=klucz-do-api
 SEARCH_DAYS=10
 ```
 
+Wartość `SEARCH_DAYS` określa liczbę dni wstecz, z których pobierane są
+wiadomości. Ustaw `0`, aby przeszukać całą skrzynkę bez ograniczenia daty.
+
 2. Pliki wyjściowe (JSON/HTML) zostaną zapisane w lokalizacjach podanych w konfiguracji.
 
 ## Uruchomienie

--- a/vinted_orders.py
+++ b/vinted_orders.py
@@ -222,8 +222,11 @@ def get_vinted_orders(cache):
         mail.select(FOLDER)
 
         last_uid = cache.get("last_uid", 0)
-        since_date = (now - timedelta(days=SEARCH_DAYS)).strftime("%d-%b-%Y")
-        status, data = mail.uid("search", None, f"SINCE {since_date}")
+        if SEARCH_DAYS > 0:
+            since_date = (now - timedelta(days=SEARCH_DAYS)).strftime("%d-%b-%Y")
+            status, data = mail.uid("search", None, f"SINCE {since_date}")
+        else:
+            status, data = mail.uid("search", None, "ALL")
         if status != "OK":
             print("❌ Nie można pobrać wiadomości.")
             return cache


### PR DESCRIPTION
## Summary
- allow searching the entire mailbox when `SEARCH_DAYS` is `0`
- document `SEARCH_DAYS` behaviour in README and `.env.example`

## Testing
- `python -m py_compile vinted_orders.py`

------
https://chatgpt.com/codex/tasks/task_e_68504b6d3bd8832fa55e1dea06b035d8