### PR TITLE
Enhance card lookup via set.id and improve logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ Wymagane są zmienne `YT_API_KEY` oraz `YT_CHANNEL_ID` w pliku `.env`. Wynik zos
 - **alert.html** – odtwarza plik *Transition.webm* w momencie pojawienia się nowego zamówienia.
 - **karty.html** – wyświetla nazwy i grafiki kart Pokémon z najnowszego zamówienia.
 
+Do wyszukiwania kart wykorzystywany jest teraz identyfikator `set.id`, dzięki czemu możliwe jest odnalezienie kart z zagranicznych wersji zestawów.
+
 Pliki te można dodać jako źródło przeglądarki w OBS.
 
 ## Licencja


### PR DESCRIPTION
## Summary
- allow `search_card_in_api` to accept optional `set_code`
- use `set.id` and number in the primary API query
- fall back to name + number when needed
- log HTTP status codes for API requests
- forward set code captured from email body
- document the new behaviour in README

## Testing
- `python -m py_compile vinted_orders.py`

------
https://chatgpt.com/codex/tasks/task_e_6862bee19d34832fbf74d61b126c2b3d