### PR TITLE
Support placeholder for cards without image

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Wymagane są zmienne `YT_API_KEY` oraz `YT_CHANNEL_ID` w pliku `.env`. Wynik zos
 - **karty.html** – wyświetla nazwy i grafiki kart Pokémon z najnowszego zamówienia.
 
 Do wyszukiwania kart wykorzystywany jest teraz identyfikator `set.id`, dzięki czemu możliwe jest odnalezienie kart z zagranicznych wersji zestawów.
+Jeżeli danej karty nie uda się odnaleźć w API, jej nazwa wraz z numerem zostanie pokazana w ramce o proporcjach prawdziwej karty.
 
 Pliki te można dodać jako źródło przeglądarki w OBS.
 

--- a/karty.html
+++ b/karty.html
@@ -69,6 +69,22 @@
       position: relative;
       box-shadow: 0 8px 24px rgba(0,0,0,0.5);
       border-radius: 12px;
+      display: none;
+    }
+
+    #card-placeholder {
+      width: 100%;
+      aspect-ratio: 63 / 88;
+      border: 2px dashed rgba(255,255,255,0.6);
+      border-radius: 12px;
+      display: none;
+      align-items: center;
+      justify-content: center;
+      text-align: center;
+      font-size: 32px;
+      padding: 10px;
+      box-shadow: 0 8px 24px rgba(0,0,0,0.5);
+      opacity: 0;
     }
 
     .fade-in-left {
@@ -109,6 +125,7 @@
 
 <div id="card-container">
   <div id="card-name"></div>
+  <div id="card-placeholder"></div>
   <img id="card-image" src="" alt="Karta Pokémon" />
 </div>
 
@@ -124,22 +141,41 @@
   function showCard(card) {
     const nameEl = document.getElementById("card-name");
     const imageEl = document.getElementById("card-image");
+    const placeholderEl = document.getElementById("card-placeholder");
 
     return new Promise(resolve => {
-      nameEl.textContent = card.name;
-      imageEl.src = card.image;
+      nameEl.textContent = card.name + (card.number ? ` (${card.number})` : "");
 
+      if (card.image) {
+        imageEl.src = card.image;
+        imageEl.style.display = "block";
+        placeholderEl.style.display = "none";
+        imageEl.className = "fade-in-left";
+      } else {
+        placeholderEl.textContent = `${card.name} (${card.number})`;
+        placeholderEl.style.display = "flex";
+        imageEl.style.display = "none";
+        placeholderEl.className = "fade-in-left";
+      }
       nameEl.className = "fade-in-left";
-      imageEl.className = "fade-in-left";
 
       setTimeout(() => {
         nameEl.className = "fade-out-right";
-        imageEl.className = "fade-out-right";
+        if (card.image) {
+          imageEl.className = "fade-out-right";
+        } else {
+          placeholderEl.className = "fade-out-right";
+        }
       }, 3000);
 
       setTimeout(() => {
         nameEl.className = "";
-        imageEl.className = "";
+        if (card.image) {
+          imageEl.className = "";
+        } else {
+          placeholderEl.className = "";
+          placeholderEl.style.display = "none";
+        }
         resolve();
       }, 4000);
     });

--- a/vinted_orders.py
+++ b/vinted_orders.py
@@ -139,6 +139,14 @@ def extract_cards_from_body(body):
                 f"❌ Nie znaleziono karty {clean_name} ({set_code} {number}). "
                 "Sprawdź set.id i numer."
             )
+            # Fall back to basic info so the card is not skipped
+            results.append({
+                "name": clean_name,
+                "set": set_code,
+                "number": number,
+                "image": None,
+            })
+            print(f"ℹ️ Dodano kartę bez obrazu: {clean_name} ({set_code} {number})")
     return results
 
 def load_cache():


### PR DESCRIPTION
## Summary
- fall back to showing card name when image is missing
- render placeholder frame in `karty.html`
- mention missing image handling in README

## Testing
- `python -m py_compile vinted_orders.py`

------
https://chatgpt.com/codex/tasks/task_e_6862c1dc46ac832fb934853ccdcda345