### PR TITLE
Fix detection of Japanese card names

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Wymagane są zmienne `YT_API_KEY` oraz `YT_CHANNEL_ID` w pliku `.env`. Wynik zos
 
 Do wyszukiwania kart wykorzystywany jest teraz identyfikator `set.id`, dzięki czemu możliwe jest odnalezienie kart z zagranicznych wersji zestawów.
 Jeżeli danej karty nie uda się odnaleźć w API, jej nazwa wraz z numerem zostanie pokazana w ramce o proporcjach prawdziwej karty.
+Skrypt rozpoznaje teraz nazwy kart zapisane także w innych alfabetach (np. japońskim), dzięki czemu nie zostaną pominięte podczas parsowania wiadomości.
 
 Pliki te można dodać jako źródło przeglądarki w OBS.
 

--- a/vinted_orders.py
+++ b/vinted_orders.py
@@ -117,11 +117,12 @@ def extract_cards_from_body(body):
     text = soup.get_text()
     # W treści wiadomości karty mogą mieć format np.
     # "Hydreigon ex (SVP 119)" lub "Hydreigon ex (SVP 119/198)".
-    # Dotychczasowy wzorzec nie obsługiwał znaków takich jak "-" czy "/".
-    # Some Pokémon names contain letters with diacritics (e.g. "Pokémon").
-    # Allow a broader range of unicode letters so such names are detected.
+    # Poprzedni wzorzec obejmował jedynie łacińskie litery, co uniemożliwiało
+    # poprawne wykrywanie kart o nazwach zapisanych np. po japońsku. Teraz
+    # dopasowujemy dowolne znaki do napotkania nawiasu otwierającego, dzięki
+    # czemu parser wychwyci również nazwy w innych alfabetach.
     pattern = (
-        r"([\wÀ-ÖØ-öø-ÿ][\wÀ-ÖØ-öø-ÿ ':,-]*[\wÀ-ÖØ-öø-ÿ])\s*"
+        r"([^()]+?)\s*"
         r"\(([A-Za-z0-9-]+)\s+#?([A-Za-z0-9/]+)\)"
     )
     matches = re.findall(pattern, text, flags=re.IGNORECASE)


### PR DESCRIPTION
## Summary
- broaden pattern for parsing card names so non-Latin characters (e.g. Japanese) are recognised
- document handling of names in other alphabets

## Testing
- `python -m py_compile vinted_orders.py youtube_videos.py vinted_orders_old.py`

------
https://chatgpt.com/codex/tasks/task_e_6862c6741868832f87022c4582935af6